### PR TITLE
Fix httpAgent reference assignment

### DIFF
--- a/lib/network.js
+++ b/lib/network.js
@@ -15,7 +15,7 @@ class Network {
         this._responseTimes = {};
         this._server = server;
         this._httpAgents = [].concat(httpAgents || Http.globalAgent);
-        this._httpAgents = [].concat(httpsAgents || Https.globalAgent);
+        this._httpsAgents = [].concat(httpsAgents || Https.globalAgent);
 
         this._server.on('request-internal', (request, event, tags) => {
 
@@ -97,7 +97,7 @@ class Network {
 
             const result = {
                 http: Network.getSocketCount(this._httpAgents),
-                https: Network.getSocketCount(this._httpAgents)
+                https: Network.getSocketCount(this._httpsAgents)
             };
             callback(null, result);
         };


### PR DESCRIPTION
httpAgent stats were not being displayed because local references to the agent(s) was overwritten by a reference to either the global or user supplied httpsAgent(s)

end result was that http agents stats were not visible
