### PR TITLE
Add config flag dontResetNetworkCounters

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Creates a new Oppsy object.
 - `[config]` - optional configuration object
   - `httpAgents` - the list of httpAgents to report socket information about. Can be a single http.Agent or an array of agents objects. Defaults to Http.globalAgent.
   - `httpsAgents` - the list of httpsAgents to report socket information about. Can be a single https.Agent or an array of agents. Defaults to Https.globalAgent.
+  - `dontResetNetworkCounters` - true/false. If true; do not reset network counters (request and response time) every time metrics are sent. Results in a counter-like behaviour instead of gauge.
+
 
 The oppsy object is an EventEmitter so it exposes the same API(`.on` and `.emit`) as the Node EventEmitter object. After it is started, it emits an "ops" event after a set interval with the collected ops information as the event payload.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,6 +15,7 @@ class Oppsy extends Events.EventEmitter {
 
         super();
         config = config || {};
+        this.config = config || {};
         this._networkMonitor = new NetworkMonitor(server, config.httpAgents, config.httpsAgents);
         this._tasks = {
             osload: OsMonitor.loadavg,
@@ -59,7 +60,9 @@ class Oppsy extends Events.EventEmitter {
                 this.emit('error', err);
             }
             finally {
-                this._networkMonitor.reset();
+                if(this.config.dontResetNetworkCounters == true){
+                    this._networkMonitor.reset();
+                }
             }
         }, interval);
     }
@@ -67,7 +70,9 @@ class Oppsy extends Events.EventEmitter {
     stop() {
 
         clearInterval(this._interval);
-        this._networkMonitor.reset();
+        if(this.config.dontResetNetworkCounters == true){
+            this._networkMonitor.reset();
+        }
         this.emit('stop');
     }
 }


### PR DESCRIPTION
This PR adds a dontResetNetworkCounters config flag. It makes it possible to disable the reset of network counters every time the counters are read.

Why? Many times it's preferable to have raw counters available in the time series database. Having a counter that resets on it's own interval, which may not be the exact same interval the rest of the monitoring pipeline, can cause inconsistencies in the data as seen in the time series database.

Using raw counters ensures that the aggregate sums are correct, regardless of the collection intervals in the monitoring pipeline. It is easy to get instant-values by using for example `rate(counter[5m])` ( https://prometheus.io/docs/prometheus/latest/querying/functions/#rate() ).

An forgive me for the code quality, I'm a monitoring/ops person and not a professional developer 👼 