### PR TITLE
Fix race condition

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -53,7 +53,9 @@ class Oppsy extends Events.EventEmitter {
                     emit[taskName] = results.shift();
                 }
 
-                this.emit('ops', emit);
+                // Emit a deep copy so we can modify this data internall without
+                // affecting listeners.
+                this.emit('ops', Hoek.clone(emit));
             }
             catch (err) {
                 this.emit('error', err);


### PR DESCRIPTION
I found a race condition where the event data could be modified by oppsy before it was consumed by any listeners. This change makes sure oppsy returns a deep copy of the event data to any listeners.