### PR TITLE
Add missing namespace to hoek dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "plugin"
   ],
   "dependencies": {
-    "hoek": "6.x.x"
+    "@hapi/hoek": "6.x.x"
   },
   "devDependencies": {
     "@hapi/code": "5.x.x",


### PR DESCRIPTION
Noticed that oppsy is triggering a warning on install due to "hoek" missing the `@hapi/` prefix when installing `@hapi/good`

```warning @hapi/good > @hapi/oppsy > hoek@6.1.3: This module has moved and is now available at @hapi/hoek. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues.```