### PR TITLE
Ajouter les requêts HTTP actives

### DIFF
--- a/lib/network.js
+++ b/lib/network.js
@@ -26,9 +26,12 @@ module.exports = internals.Network = class {
             this._requests[port] = this._requests[port] || {
                 total: 0,
                 disconnects: 0,
-                statusCodes: {}
+                statusCodes: {},
+                activeRequests:0,
             };
             this._requests[port].total++;
+            this._requests[port].activeRequests++;
+
 
             request.events.once('disconnect', () => {
 
@@ -64,6 +67,8 @@ module.exports = internals.Network = class {
                 this._requests[port].statusCodes[statusCode] = this._requests[port].statusCodes[statusCode] || 0;
                 this._requests[port].statusCodes[statusCode]++;
             }
+
+            this._requests[port].activeRequests--;
         });
 
         this.requests = () => {

--- a/lib/network.js
+++ b/lib/network.js
@@ -109,7 +109,8 @@ module.exports = internals.Network = class {
                 this._requests[ports[i]] = {
                     total: 0,
                     disconnects: 0,
-                    statusCodes: {}
+                    statusCodes: {},
+                    activeRequests: this._requests[ports[i]].activeRequests
                 };
                 this._responseTimes[ports[i]] = {
                     count: 0,

--- a/lib/network.js
+++ b/lib/network.js
@@ -3,9 +3,6 @@
 const Http = require('http');
 const Https = require('https');
 
-const Hoek = require('@hapi/hoek');
-
-
 const internals = {};
 
 
@@ -13,62 +10,51 @@ module.exports = internals.Network = class {
 
     constructor(server, httpAgents, httpsAgents) {
 
-        this._requests = {};
-        this._responseTimes = {};
+        this._requests = {
+            total: 0,
+            disconnects: 0,
+            statusCodes: {},
+            activeRequests: 0
+        };
+        this._responseTimes = {
+            count: 0,
+            total: 0,
+            max: 0
+        };
         this._server = server;
         this._httpAgents = [].concat(httpAgents || Http.globalAgent);
         this._httpsAgents = [].concat(httpsAgents || Https.globalAgent);
 
         this._server.ext('onRequest', (request, h) => {
 
-            const port = this._server.info.port;
-
-            this._requests[port] = this._requests[port] || {
-                total: 0,
-                disconnects: 0,
-                statusCodes: {},
-                activeRequests:0,
-            };
-            this._requests[port].total++;
-            this._requests[port].activeRequests++;
-
+            this._requests.total++;
+            this._requests.activeRequests++;
 
             request.events.once('disconnect', () => {
 
-                this._requests[port].disconnects++;
+                this._requests.disconnects++;
             });
 
             return h.continue;
         });
         this._server.events.on('response', (request) => {
 
-            const port = this._server.info.port;
-
-            if (!this._requests[port]) {
-                return;
-            }
-
             const msec = Date.now() - request.info.received;
             const statusCode = request.response && request.response.statusCode;
 
-            const portResponse = this._responseTimes[port] = (this._responseTimes[port] || {
-                count: 0,
-                total: 0,
-                max: 0
-            });
-            portResponse.count++;
-            portResponse.total += msec;
+            this._responseTimes.count++;
+            this._responseTimes.total += msec;
 
-            if (portResponse.max < msec) {
-                portResponse.max = msec;
+            if (this._responseTimes.max < msec) {
+                this._responseTimes.max = msec;
             }
 
             if (statusCode) {
-                this._requests[port].statusCodes[statusCode] = this._requests[port].statusCodes[statusCode] || 0;
-                this._requests[port].statusCodes[statusCode]++;
+                this._requests.statusCodes[statusCode] = this._requests.statusCodes[statusCode] || 0;
+                this._requests.statusCodes[statusCode]++;
             }
 
-            this._requests[port].activeRequests--;
+            this._requests.activeRequests--;
         });
 
         this.requests = () => {
@@ -78,20 +64,17 @@ module.exports = internals.Network = class {
 
         this.responseTimes = () => {
 
-            const ports = Object.keys(this._responseTimes);
-            const overview = {};
-            for (let i = 0; i < ports.length; ++i) {
-                const port = ports[i];
-                const count = Hoek.reach(this, `_responseTimes.${port}.count`, {
-                    default: 1
-                });
-                overview[port] = {
-                    avg: this._responseTimes[port].total / count,
-                    max: this._responseTimes[port].max
+            if (this._responseTimes.count === 0) {
+                return {
+                    avg: null,
+                    max: null
                 };
             }
 
-            return overview;
+            return {
+                avg: this._responseTimes.total / this._responseTimes.count,
+                max: this._responseTimes.max
+            };
         };
 
         this.sockets = () => {
@@ -104,20 +87,18 @@ module.exports = internals.Network = class {
 
         this.reset = () => {
 
-            const ports = Object.keys(this._requests);
-            for (let i = 0; i < ports.length; ++i) {
-                this._requests[ports[i]] = {
-                    total: 0,
-                    disconnects: 0,
-                    statusCodes: {},
-                    activeRequests: this._requests[ports[i]].activeRequests
-                };
-                this._responseTimes[ports[i]] = {
-                    count: 0,
-                    total: 0,
-                    max: 0
-                };
-            }
+            this._requests = {
+                total: 0,
+                disconnects: 0,
+                statusCodes: {},
+                activeRequests: this._requests.activeRequests
+            };
+            this._responseTimes = {
+                count: 0,
+                total: 0,
+                max: 0
+            };
+
         };
     }
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,11 @@
+## :jack_o_lantern: Problème
+> _Décrivez ici le besoin ou l'intention couvert par cette Pull Request._
+
+## :bat: Proposition
+> _Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés._
+
+## :spider_web: Remarques
+> _Des infos supplémentaires, trucs et astuces ?_
+
+## :ghost: Pour tester
+> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._

--- a/test/index.js
+++ b/test/index.js
@@ -330,7 +330,6 @@ describe('Oppsy', { retry: true }, () => {
                 total: 1,
                 disconnects: 1,
                 statusCodes: {
-                    '499': 1
                 }
             };
 

--- a/test/index.js
+++ b/test/index.js
@@ -81,14 +81,11 @@ describe('Oppsy', { retry: true }, () => {
             }
 
             await Utils.timeout(500);
-
-            expect(network._requests).to.have.length(1);
-            expect(network._requests[server.info.port]).to.exist();
-            expect(network._requests[server.info.port].total).to.equal(20);
-            expect(network._requests[server.info.port].statusCodes[200]).to.equal(20);
-            expect(network._requests[server.info.port].activeRequests).to.equal(0);
-            expect(network._responseTimes[server.info.port]).to.exist();
-            expect(network._responseTimes[server.info.port]).to.exist();
+            expect(network._requests).to.exist();
+            expect(network._requests.total).to.equal(20);
+            expect(network._requests.statusCodes[200]).to.equal(20);
+            expect(network._requests.activeRequests).to.equal(0);
+            expect(network._responseTimes).to.exist();
 
         });
 
@@ -108,9 +105,11 @@ describe('Oppsy', { retry: true }, () => {
                 path: '/',
                 handler: (request, h) => {
 
-                    return new Promise((resolve)=>{
-                        setTimeout(()=>{resolve('ok')},1000)
-                    })
+                    return new Promise((resolve) => {
+                        setTimeout(() => {
+                            resolve('ok');
+                        },1000);
+                    });
                 }
             });
 
@@ -132,12 +131,16 @@ describe('Oppsy', { retry: true }, () => {
 
             await Utils.timeout(500);
 
-            expect(network._requests).to.have.length(1);
-            expect(network._requests[server.info.port]).to.exist();
-            expect(network._requests[server.info.port].total).to.equal(20);
-            expect(network._requests[server.info.port].statusCodes).to.equal({});
-            expect(network._requests[server.info.port].activeRequests).to.not.equal(0);
-            expect(network._responseTimes[server.info.port]).to.not.exist();
+            expect(network._requests).to.have.length(4);
+            expect(network._requests).to.exist();
+            expect(network._requests.total).to.equal(20);
+            expect(network._requests.statusCodes).to.equal({});
+            expect(network._requests.activeRequests).to.not.equal(0);
+            expect(network._responseTimes).to.equal({
+                count: 0,
+                total: 0,
+                max: 0
+            });
 
 
         });
@@ -175,17 +178,15 @@ describe('Oppsy', { retry: true }, () => {
 
             await Utils.timeout(300);
 
-            const port = server.info.port;
+            expect(network._requests).to.exist();
+            expect(network._requests.total).to.equal(10);
+            expect(network._requests.statusCodes[200]).to.equal(10);
 
-            expect(network._requests[port]).to.exist();
-            expect(network._requests[port].total).to.equal(10);
-            expect(network._requests[port].statusCodes[200]).to.equal(10);
-
-            expect(network._responseTimes[port]).to.exist();
+            expect(network._responseTimes).to.exist();
 
             network.reset();
 
-            expect(network._requests[port]).to.equal({
+            expect(network._requests).to.equal({
                 total: 0,
                 disconnects: 0,
                 statusCodes: {},
@@ -193,7 +194,7 @@ describe('Oppsy', { retry: true }, () => {
             });
 
 
-            expect(network._responseTimes[port]).to.equal({
+            expect(network._responseTimes).to.equal({
                 count: 0,
                 total: 0,
                 max: 0
@@ -211,9 +212,11 @@ describe('Oppsy', { retry: true }, () => {
                 method: 'GET',
                 path: '/',
                 handler: (request, h) => {
-                    return new Promise((resolve)=>{
-                        setTimeout(()=>{resolve('ok')},10000)
-                    })
+                    return new Promise((resolve) => {
+                        setTimeout(() => {
+                            resolve('ok');
+                        },10000);
+                    });
                 }
             });
 
@@ -235,18 +238,20 @@ describe('Oppsy', { retry: true }, () => {
 
             await Utils.timeout(100);
 
-            const port = server.info.port;
+            expect(network._requests).to.exist();
+            expect(network._requests.total).to.equal(10);
+            expect(network._requests.statusCodes).to.equal({});
+            expect(network._requests.activeRequests).to.equal(10);
 
-            expect(network._requests[port]).to.exist();
-            expect(network._requests[port].total).to.equal(10);
-            expect(network._requests[port].statusCodes).to.equal({});
-            expect(network._requests[port].activeRequests).to.equal(10);
-
-            expect(network._responseTimes).to.equal({});
+            expect(network._responseTimes).to.equal({
+                count: 0,
+                total: 0,
+                max: 0
+            });
 
             network.reset();
 
-            expect(network._requests[port]).to.equal({
+            expect(network._requests).to.equal({
                 total: 0,
                 disconnects: 0,
                 statusCodes: {},
@@ -254,7 +259,7 @@ describe('Oppsy', { retry: true }, () => {
             });
 
 
-            expect(network._responseTimes[port]).to.equal({
+            expect(network._responseTimes).to.equal({
                 count: 0,
                 total: 0,
                 max: 0
@@ -372,13 +377,12 @@ describe('Oppsy', { retry: true }, () => {
                 network.sockets()
             ]);
 
-            const port = server.info.port;
 
             expect(sockets.http.total).to.be.at.least(10);
             expect(sockets.https.total).to.be.equal(10);
 
-            expect(response[port].avg).to.be.at.least(1);
-            expect(response[port].max).to.be.at.least(1);
+            expect(response.avg).to.be.at.least(1);
+            expect(response.max).to.be.at.least(1);
         });
 
         it('tracks server disconnects', async () => {
@@ -443,8 +447,7 @@ describe('Oppsy', { retry: true }, () => {
 
             const result = await network.requests();
 
-            const requests = {};
-            requests[server.info.port] = {
+            const requests = {
                 total: 1,
                 disconnects: 1,
                 activeRequests: 0,
@@ -490,9 +493,9 @@ describe('Oppsy', { retry: true }, () => {
                     port: server.info.port
                 }, () => {
 
-                    expect(network._requests[server.info.port]).to.exist();
-                    expect(network._requests[server.info.port].total).to.equal(1);
-                    expect(network._requests[server.info.port].statusCodes).to.equal({});
+                    expect(network._requests).to.exist();
+                    expect(network._requests.total).to.equal(1);
+                    expect(network._requests.statusCodes).to.equal({});
                     resolve();
                 });
             });

--- a/test/oppsy.js
+++ b/test/oppsy.js
@@ -171,8 +171,16 @@ describe('Oppsy', () => {
 
         await Utils.timeout(500);
 
-        expect(_data.requests).to.equal({});
-        expect(_data.responseTimes).to.equal({});
+        expect(_data.requests).to.equal( {
+            total: 0,
+            disconnects: 0,
+            statusCodes: {},
+            activeRequests: 0 }
+        );
+        expect(_data.responseTimes).to.equal({
+            max: null,
+            avg: null
+        });
         expect(_data.sockets).to.equal({
             http: {
                 total: 0


### PR DESCRIPTION
## :jack_o_lantern: Problème
Le nombre de requêtes http en cours n'est pas tracée

## :bat: Proposition
Les ajouter

## :spider_web: Remarques
Suppression de la notion de port

## :ghost: Pour tester
Vérifier la CI
